### PR TITLE
fix(client): register settings card as keyed slot

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -549,7 +549,7 @@ await check('E1 client apply mounts the sidebar entry and studio (jsdom)', async
     assert.equal(connectionStatus?.getAttribute('data-connected'), 'false', 'missing key is shown as disconnected')
     // The settings card registered into the official plugin-config slot.
     assert.equal(registered.length, 1)
-    assert.equal(registered[0].id, 'imagegen')
+    assert.equal(registered[0].key, 'dsh-imagegen')
     assert.equal(registered[0].name, 'settings.plugin.item')
 
     // --- save-flow regression: a secret field's save must report success ---

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -44,7 +44,7 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
      * same shape so this package can register without depending on the
      * sibling UI package.
      */
-    'settings.plugin.item': { kind: 'list'; scope: 'root'; owner: ImageGenPluginItemOwnerProps }
+    'settings.plugin.item': { kind: 'keyed'; scope: 'root'; owner: ImageGenPluginItemOwnerProps }
   }
 }
 
@@ -87,8 +87,7 @@ export function apply(ctx: ClientContext): void {
   const settingsCard = new ImageGenSettingsCardController(scope)
   ctx.slots.inject('settings.plugin.item', () => ctx.slots.register({
     name: 'settings.plugin.item',
-    id: 'imagegen',
-    order: 30,
+    key: 'dsh-imagegen',
     locale: NS,
     inject: () => settingsCard.inject(),
   }, ImageGenSettingsCard))


### PR DESCRIPTION
Summary: update settings.plugin.item to its current keyed contract, use the dsh-imagegen settings namespace as the registration key, and add a smoke regression. This prevents the client loader error: keyed slot settings.plugin.item requires options.key. Verification: pnpm typecheck; pnpm build; node scripts/smoke.mjs.