### PR TITLE
fix(engine): only forward the channel API key to the API's own origin

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -98,6 +98,16 @@ await check('A3 updater parses stable Releases and caches checks', async () => {
 const pngBytes = Buffer.from('89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c6360000002000100ffff03000006000557bfabd40000000049454e44ae426082', 'hex')
 let activeGenerationRequests = 0
 let maxGenerationRequests = 0
+// A second listener = a different origin (port) from the API base. It stands in
+// for a malicious relay pointing image URLs at an attacker-controlled host.
+const foreignAuthHeaders = []
+const resultAuthHeaders = []
+const foreignHost = createServer((req, res) => {
+  foreignAuthHeaders.push(req.headers.authorization)
+  res.writeHead(200, { 'content-type': 'image/png' })
+  res.end(pngBytes)
+})
+await new Promise(resolve => foreignHost.listen(0, '127.0.0.1', resolve))
 const upstream = createServer(async (req, res) => {
   const url = new URL(req.url ?? '/', 'http://127.0.0.1')
   if (url.pathname === '/v1/models') {
@@ -121,7 +131,7 @@ const upstream = createServer(async (req, res) => {
     const body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
     assert.equal(req.headers.authorization, 'Bearer sk-test')
     assert.ok(body.model === 'gpt-image-2' || body.model === 'grok-imagine-image')
-    assert.ok(body.prompt === 'a cat' || body.prompt === 'a mismatch cat' || body.prompt === 'a background cat' || body.prompt === 'cancel this' || body.prompt === 'signed urls' || body.prompt === 'parallel one' || body.prompt === 'parallel two')
+    assert.ok(body.prompt === 'a cat' || body.prompt === 'a mismatch cat' || body.prompt === 'a background cat' || body.prompt === 'cancel this' || body.prompt === 'signed urls' || body.prompt === 'foreign url' || body.prompt === 'parallel one' || body.prompt === 'parallel two')
     if (body.model === 'gpt-image-2') {
       assert.equal(body.size, '1024x1024')
       assert.equal(body.quality, 'high')
@@ -132,7 +142,7 @@ const upstream = createServer(async (req, res) => {
     // The engine never sends `n`: Responses-API gateways reject the batch
     // parameter, so the requested count is satisfied by parallel requests.
     assert.equal(body.n, undefined)
-    assert.equal(body.detail, body.model === 'grok-imagine-image' || body.prompt === 'signed urls' ? undefined : 'standard')
+    assert.equal(body.detail, body.model === 'grok-imagine-image' || body.prompt === 'signed urls' || body.prompt === 'foreign url' ? undefined : 'standard')
     if (body.prompt === 'parallel one' || body.prompt === 'parallel two') {
       activeGenerationRequests += 1
       maxGenerationRequests = Math.max(maxGenerationRequests, activeGenerationRequests)
@@ -140,7 +150,9 @@ const upstream = createServer(async (req, res) => {
       activeGenerationRequests -= 1
     }
     res.writeHead(200, { 'content-type': 'application/json' })
-    const data = body.prompt === 'signed urls'
+    const data = body.prompt === 'foreign url'
+      ? [{ url: `http://127.0.0.1:${foreignHost.address().port}/steal.png` }]
+      : body.prompt === 'signed urls'
       ? [
           { b64_json: '', url: `http://127.0.0.1:${upstream.address().port}/image/gcs-signed.png?X-Goog-Credential=test&X-Goog-Signature=test` },
           { b64_json: '   ', url: `http://127.0.0.1:${upstream.address().port}/image/s3-signed.png?X-Amz-Credential=test&X-Amz-Signature=test` },
@@ -168,6 +180,10 @@ const upstream = createServer(async (req, res) => {
     return
   }
   if (url.pathname === '/image/result.png') {
+    // Same-origin downloads (B1: API base is this server) keep the key; other
+    // suites (Qwen / async providers on their own ports) point here from a
+    // foreign origin and must arrive without it.
+    resultAuthHeaders.push(req.headers.authorization)
     res.writeHead(200, { 'content-type': 'image/png' })
     res.end(pngBytes)
     return
@@ -202,6 +218,7 @@ await check('B1 text generation normalizes b64_json + url items', async () => {
   assert.equal(result.images[0].revisedPrompt, 'a refined cat')
   assert.equal(result.images[1].b64, pngBytes.toString('base64'))
   assert.equal(result.images[1].mime, 'image/png')
+  assert.equal(resultAuthHeaders.at(-1), 'Bearer sk-test', 'same-origin result URLs keep the channel API key')
 })
 
 await check('B2 signed URLs bypass API-key auth and empty base64 falls back to URL', async () => {
@@ -212,6 +229,17 @@ await check('B2 signed URLs bypass API-key auth and empty base64 falls back to U
   assert.equal(result.images.length, 2)
   assert.equal(result.images[0].b64, pngBytes.toString('base64'))
   assert.equal(result.images[1].b64, pngBytes.toString('base64'))
+})
+
+await check('B2b result URLs on a foreign origin never receive the channel API key', async () => {
+  const result = await host.generateImage(
+    { apiUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-test' },
+    { mode: 'text', model: 'gpt-image-2', prompt: 'foreign url', size: '1:1', quality: '4k', n: 1, detail: '' },
+  )
+  assert.equal(result.images.length, 1)
+  assert.equal(result.images[0].b64, pngBytes.toString('base64'))
+  assert.equal(foreignAuthHeaders.length, 1)
+  assert.equal(foreignAuthHeaders[0], undefined, 'a foreign-origin image URL must not carry the Bearer key')
 })
 
 await check('B3 edit mode sends multipart and normalizes', async () => {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -237,6 +237,20 @@ function isPresignedUrl(value: string): boolean {
   )
 }
 
+/**
+ * Whether a result URL lives on the same origin as the configured API base.
+ * The upstream Bearer key is only ever forwarded to this origin: a provider
+ * (or a compromised relay) that hands back an image URL on a foreign host
+ * must not be able to harvest the key through that download.
+ */
+function isSameOriginAsApi(value: string, apiUrl: string): boolean {
+  try {
+    return new URL(value).origin === new URL(apiUrl).origin
+  } catch {
+    return false
+  }
+}
+
 /** Clamp the requested image count into the API-accepted range. */
 function clampCount(n: number): number {
   if (!Number.isFinite(n)) return 1
@@ -367,10 +381,15 @@ async function normalizeItem(
   try {
     let response: Response
     try {
+      // Forward the key only to the API's own origin, and never to a
+      // presigned object-storage URL (which carries its own credentials).
+      const forwardKey = upstream.apiKey !== ''
+        && !isPresignedUrl(url)
+        && isSameOriginAsApi(url, upstream.apiUrl)
       response = await fetch(url, {
-        ...isPresignedUrl(url) || upstream.apiKey === ''
-          ? {}
-          : { headers: { authorization: `Bearer ${upstream.apiKey}` } },
+        ...forwardKey
+          ? { headers: { authorization: `Bearer ${upstream.apiKey}` } }
+          : {},
         signal: budget.signal,
       })
     } catch (error) {


### PR DESCRIPTION
## 问题 / Problem

`normalizeItem()` 在下载上游返回的图片 URL 时，除预签名对象存储链接外，一律附带 `Authorization: Bearer <渠道 apiKey>`（`src/engine.ts` 原 L370-373）。这意味着一个恶意或被攻陷的中转服务商只需在响应里返回一个指向自己主机的图片 URL，就能在下载请求里拿到用户的 API key。

When an upstream returns image results as URLs, `normalizeItem()` downloaded them with the channel's Bearer key unless the URL looked presigned. A provider (or compromised relay) could return an image URL on any host it controls and harvest the key from that download.

## 修复 / Fix

只有当结果 URL 与配置的 `apiUrl` **同源**（scheme + host + port）时才转发 key。预签名 URL 行为不变；正规服务商的 CDN 链接本就不需要认证，不受影响。

Forward the key only when the result URL shares the origin of the configured API base. Presigned URLs keep bypassing auth as before; provider CDN links that need no auth are unaffected.

## 测试 / Tests

- 新增 `B2b`：第二个端口上的监听器模拟异源主机，断言下载请求不带 `Authorization`
- `B1` 增加断言：同源下载仍携带 key
- 反向验证：撤掉修复后 `B2b` 失败，恢复后通过；`tsc --noEmit`、`tsdown`、完整 `smoke.mjs`（含 B7 Seedream / B8 Zhipu / B9 Qwen / B10-12 async 等跨端口场景）全部通过

Thanks for the plugin — found this while auditing it before installing.
