### PR TITLE
fix(prompt-enhancer): strip reasoning-model <think> blocks

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -167,6 +167,21 @@ const upstream = createServer(async (req, res) => {
     res.end(JSON.stringify({ data: [{ b64_json: pngBytes.toString('base64') }] }))
     return
   }
+  if (url.pathname === '/v1/chat/completions') {
+    const chunks = []
+    for await (const chunk of req) chunks.push(chunk)
+    const body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+    assert.equal(req.headers.authorization, 'Bearer sk-test')
+    const asked = body.messages.at(-1).content
+    const reply = asked === 'think leak'
+      ? '<think>\u9996\u5148\u5206\u6790\u7528\u6237\u9700\u6c42\u2026\uff08\u5927\u6bb5\u63a8\u7406\uff09</think>\nA lighthouse at dusk over a stormy sea.'
+      : asked === 'dangling think'
+        ? '<think>reasoning that never closes'
+        : 'A calm meadow under morning light.'
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ choices: [{ message: { content: reply } }] }))
+    return
+  }
   if (url.pathname === '/image/result.png') {
     res.writeHead(200, { 'content-type': 'image/png' })
     res.end(pngBytes)
@@ -688,6 +703,7 @@ let storageProbeEndpoint = ''
 const routes = host.makeRoutes({
   settings: seam,
   resolve: () => ({ apiUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-test' }),
+  resolvePrompt: () => ({ apiUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-test', model: 'chat-test' }),
   history,
   templates,
   favorites,
@@ -725,6 +741,22 @@ const post = async (path, body, headers = {}) => {
     throw new Error(`HTTP ${response.status} returned non-JSON body: ${text || '<empty>'}`)
   }
 }
+
+await check('C0b prompt enhance strips reasoning-model <think> blocks', async () => {
+  // Closed think block: only the visible answer may reach the prompt box.
+  const leak = await post('/api/dsh-imagegen/prompt-enhance', { prompt: 'think leak' })
+  assert.equal(leak.status, 200)
+  assert.equal(leak.body.ok, true)
+  assert.equal(leak.body.prompt, 'A lighthouse at dusk over a stormy sea.')
+  // Dangling unclosed <think>: everything after it is reasoning, so the
+  // enhancer must fail loudly instead of returning the raw reasoning text.
+  const dangling = await post('/api/dsh-imagegen/prompt-enhance', { prompt: 'dangling think' })
+  assert.equal(dangling.body.ok, false)
+  assert.match(dangling.body.message, /only reasoning content/)
+  // Clean content passes through untouched.
+  const clean = await post('/api/dsh-imagegen/prompt-enhance', { prompt: 'clean please' })
+  assert.equal(clean.body.prompt, 'A calm meadow under morning light.')
+})
 
 await check('C1 settings describe serves the redacted namespace', async () => {
   const { status, body } = await post('/api/dsh-imagegen/settings/describe', {})

--- a/src/prompt-enhancer.ts
+++ b/src/prompt-enhancer.ts
@@ -109,6 +109,18 @@ export async function listPromptModels(config: PromptModelConfig): Promise<strin
   return listOpenAIModels(config)
 }
 
+/** Remove reasoning-model artifacts from a chat model's visible content:
+ *  complete `<think>…</think>` blocks first, then anything from a dangling
+ *  unclosed `<think>` to the end of the text. Reasoning models served through
+ *  OpenAI-compatible endpoints (MiniMax M3, DeepSeek R1, Qwen QVQ, …) inline
+ *  these blocks in `message.content`; leaking them into the prompt box both
+ *  pollutes the prompt and can push it past image models' length limits. */
+function stripReasoning(text: string): string {
+  const withoutClosed = text.replace(/<think>[\s\S]*?<\/think>/gi, '')
+  const dangling = /<think>/i.exec(withoutClosed)
+  return (dangling === null ? withoutClosed : withoutClosed.slice(0, dangling.index)).trim()
+}
+
 /** Expand a concise image request into a production-ready image prompt. */
 export async function enhancePrompt(config: PromptModelConfig, prompt: string): Promise<string> {
   if (config.apiUrl.trim() === '' || config.model.trim() === '') throw new Error('prompt enhancement model is not configured')
@@ -133,5 +145,7 @@ export async function enhancePrompt(config: PromptModelConfig, prompt: string): 
     ? (choices[0] as { message?: { content?: unknown } }).message?.content
     : undefined
   if (typeof content !== 'string' || content.trim() === '') throw new Error('chat model returned an empty prompt')
-  return content.trim()
+  const enhanced = stripReasoning(content)
+  if (enhanced === '') throw new Error('chat model returned only reasoning content (empty <think> payload)')
+  return enhanced
 }


### PR DESCRIPTION
## 背景 / Why

用推理模型（MiniMax M3、DeepSeek R1、Qwen QVQ 等）做"提示词增强"时，OpenAI 兼容接口会把 `<think>…</think>` 内联在 `message.content` 里，`enhancePrompt()` 原样返回，导致提示词框回显的内容最前面多出一整段推理。

Reasoning models behind OpenAI-compatible endpoints inline `<think>…</think>` in `message.content`, so the enhanced prompt came back prefixed with the whole reasoning block.

这不只是显示问题：被污染的提示词会超过图像模型的长度上限——实测 MiniMax image-01（1500 字符上限）在"增强 → 生成"链路中直接被拒（HTTP 200 + `base_resp 2013 "prompt length must be less than 1500"`）。

## 改动 / What

`enhancePrompt()` 现在：
- 先剥离完整的 `<think>…</think>` 块（可多个，忽略大小写）
- 再处理**未闭合**的 `<think>`（截断其后所有内容）
- 若剥离后没有剩余可见文本，以独立错误信息失败（`chat model returned only reasoning content`）

## 测试 / Tests

新增 smoke `C0b`（走完整 route 层）：闭合 think 块、悬空 think 块、干净内容三种情形。完整 `smoke.mjs` 通过。

Independent of #11 / #12（基于 main）。
